### PR TITLE
Make Logs Collapse

### DIFF
--- a/owmods_gui/backend/src/commands.rs
+++ b/owmods_gui/backend/src/commands.rs
@@ -611,7 +611,7 @@ pub async fn get_log_lines(
     filter_type: Option<SocketMessageType>,
     search: &str,
     state: tauri::State<'_, State>,
-) -> Result<Vec<usize>, String> {
+) -> Result<Vec<(usize, usize)>, String> {
     let logs = state.game_log.read().await;
     if let Some((lines, _)) = logs.get(&port) {
         let lines = get_logs_indices(lines, filter_type, search).map_err(e_to_str)?;

--- a/owmods_gui/backend/src/game.rs
+++ b/owmods_gui/backend/src/game.rs
@@ -1,5 +1,4 @@
 use std::{
-    default,
     fs::File,
     io::{BufWriter, Write},
     time::{SystemTime, UNIX_EPOCH},

--- a/owmods_gui/backend/src/game.rs
+++ b/owmods_gui/backend/src/game.rs
@@ -1,4 +1,5 @@
 use std::{
+    default,
     fs::File,
     io::{BufWriter, Write},
     time::{SystemTime, UNIX_EPOCH},
@@ -83,7 +84,6 @@ pub fn get_logs_indices(
     let mut indices: Vec<(usize, usize)> = vec![];
     let search = search.to_ascii_lowercase();
     let mut count = 1;
-    let mut last_line = "";
     for (line_number, line) in lines.iter().enumerate() {
         let mut include = true;
         if filter_type.is_some() || !search.trim().is_empty() {
@@ -101,7 +101,16 @@ pub fn get_logs_indices(
                 include = false;
             }
         }
-        if last_line == line.message.message {
+        let mut same = false;
+        if let Some(next_line) = lines.get(line_number + 1) {
+            if next_line.message.message == line.message.message
+                && next_line.message.message_type == line.message.message_type
+                && next_line.message.sender_name == line.message.sender_name
+            {
+                same = true;
+            }
+        }
+        if same {
             count += 1;
         } else {
             if include {
@@ -109,7 +118,6 @@ pub fn get_logs_indices(
             }
             count = 1;
         }
-        last_line = &line.message.message;
     }
     Ok(indices)
 }

--- a/owmods_gui/backend/src/game.rs
+++ b/owmods_gui/backend/src/game.rs
@@ -79,9 +79,10 @@ pub fn get_logs_indices(
     lines: &Vec<GameMessage>,
     filter_type: Option<SocketMessageType>,
     search: &str,
-) -> Result<Vec<usize>> {
-    let mut indices: Vec<usize> = vec![];
+) -> Result<Vec<(usize, usize)>> {
+    let mut indices: Vec<(usize, usize)> = vec![];
     let search = search.to_ascii_lowercase();
+    let count = 0; // TODO actually do this lol. gotta count when non filtering
     if filter_type.is_some() || !search.trim().is_empty() {
         for (line_number, line) in lines.iter().enumerate() {
             let matches_type = filter_type.is_none()
@@ -95,11 +96,12 @@ pub fn get_logs_indices(
                     .map(|v| v.to_ascii_lowercase().contains(&search))
                     .unwrap_or(false);
             if matches_type && matches_search {
-                indices.push(line_number);
+                indices.push((line_number, count));
             }
         }
     } else {
-        indices = (0..lines.len()).collect();
+        // fuck
+        indices = (0..lines.len()).map(|x| (x, 1)).collect();
     }
     Ok(indices)
 }

--- a/owmods_gui/backend/src/game.rs
+++ b/owmods_gui/backend/src/game.rs
@@ -76,30 +76,14 @@ pub fn write_log(writer: &mut BufWriter<File>, msg: &SocketMessage) -> Result<()
 }
 
 pub fn get_logs_indices(
-    lines: &Vec<GameMessage>,
+    lines: &[GameMessage],
     filter_type: Option<SocketMessageType>,
     search: &str,
 ) -> Result<Vec<(usize, usize)>> {
-    let mut indices: Vec<(usize, usize)> = vec![];
+    let mut indices = Vec::with_capacity(lines.len());
     let search = search.to_ascii_lowercase();
     let mut count = 1;
     for (line_number, line) in lines.iter().enumerate() {
-        let mut include = true;
-        if filter_type.is_some() || !search.trim().is_empty() {
-            let matches_type = filter_type.is_none()
-                || line.message.message_type == *filter_type.as_ref().unwrap();
-            let matches_search = search.is_empty()
-                || line.message.message.to_ascii_lowercase().contains(&search)
-                || line
-                    .message
-                    .sender_name
-                    .as_ref()
-                    .map(|v| v.to_ascii_lowercase().contains(&search))
-                    .unwrap_or(false);
-            if !(matches_type && matches_search) {
-                include = false;
-            }
-        }
         let mut same = false;
         if let Some(next_line) = lines.get(line_number + 1) {
             if next_line.message.message == line.message.message
@@ -112,6 +96,22 @@ pub fn get_logs_indices(
         if same {
             count += 1;
         } else {
+            let mut include = true;
+            if filter_type.is_some() || !search.trim().is_empty() {
+                let matches_type = filter_type.is_none()
+                    || line.message.message_type == *filter_type.as_ref().unwrap();
+                let matches_search = search.is_empty()
+                    || line.message.message.to_ascii_lowercase().contains(&search)
+                    || line
+                        .message
+                        .sender_name
+                        .as_ref()
+                        .map(|v| v.to_ascii_lowercase().contains(&search))
+                        .unwrap_or(false);
+                if !(matches_type && matches_search) {
+                    include = false;
+                }
+            }
             if include {
                 indices.push((line_number, count));
             }

--- a/owmods_gui/frontend/src/commands.ts
+++ b/owmods_gui/frontend/src/commands.ts
@@ -63,7 +63,7 @@ const commandInfo = {
                 filterType?: number | undefined;
                 search: string;
             },
-            number[]
+            [number, number][]
         >
     >("get_log_lines"),
     exportMods: $<ActionCommand<{ path: string }>>("export_mods"),

--- a/owmods_gui/frontend/src/components/logs/LogApp.tsx
+++ b/owmods_gui/frontend/src/components/logs/LogApp.tsx
@@ -26,7 +26,7 @@ const App = ({ port }: { port: number }) => {
     const [activeFilter, setActiveFilter] = useState<LogFilter>("Any");
     const [activeSearch, setActiveSearch] = useState<string>("");
     const [autoScroll, setAutoScroll] = useState(true);
-    const [logLines, setLogLines] = useState<number[]>([]);
+    const [logLines, setLogLines] = useState<[number, number][]>([]);
 
     const fatalErrorLabel = useTranslation("FATAL_ERROR");
 

--- a/owmods_gui/frontend/src/components/logs/LogLine.tsx
+++ b/owmods_gui/frontend/src/components/logs/LogLine.tsx
@@ -6,6 +6,7 @@ export interface LogLineProps {
     port: number;
     index: number;
     line: number;
+    count: number;
     style: CSSProperties;
     reportSize?: (i: number, l: number, size: number) => void;
 }
@@ -39,6 +40,7 @@ const LogLine = memo(
                         <span className={`message type-${msgClassName}`}>
                             {msg?.message.message}
                         </span>
+                        <span>COUNT: {props.count}</span>
                     </div>
                 </div>
             );
@@ -46,6 +48,7 @@ const LogLine = memo(
     },
     (current, next) =>
         current.line === next.line &&
+        current.count === next.count &&
         current.style.display === next.style.display &&
         current.style.height === next.style.height &&
         current.style.top === next.style.top

--- a/owmods_gui/frontend/src/components/logs/LogLine.tsx
+++ b/owmods_gui/frontend/src/components/logs/LogLine.tsx
@@ -40,7 +40,7 @@ const LogLine = memo(
                         <span className={`message type-${msgClassName}`}>
                             {msg?.message.message}
                         </span>
-                        <span>COUNT: {props.count}</span>
+                        <span className="count">{props.count}</span>
                     </div>
                 </div>
             );

--- a/owmods_gui/frontend/src/components/logs/LogLine.tsx
+++ b/owmods_gui/frontend/src/components/logs/LogLine.tsx
@@ -40,7 +40,7 @@ const LogLine = memo(
                         <span className={`message type-${msgClassName}`}>
                             {msg?.message.message}
                         </span>
-                        <span className="count">{props.count}</span>
+                        {props.count > 1 && <span className="count">{props.count}</span>}
                     </div>
                 </div>
             );

--- a/owmods_gui/frontend/src/components/logs/LogList.tsx
+++ b/owmods_gui/frontend/src/components/logs/LogList.tsx
@@ -6,7 +6,7 @@ import { LogFilter } from "./LogApp";
 
 export interface LogListProps {
     port: number;
-    logLines: number[];
+    logLines: [number, number][];
     activeFilter: LogFilter;
     search: string;
     autoScroll: boolean;
@@ -21,7 +21,7 @@ const LogList = memo((props: LogListProps) => {
         listRef.current?.resetAfterIndex(i);
     }, []);
     const getSize = useCallback(
-        (i: number) => logSizes.current[props.logLines[i]] ?? 40,
+        (i: number) => logSizes.current[props.logLines[i][0]] ?? 40,
         [props.logLines, logSizes.current]
     );
 
@@ -52,8 +52,9 @@ const LogList = memo((props: LogListProps) => {
                                 port={props.port}
                                 reportSize={reportSize}
                                 index={index}
-                                line={props.logLines[index]}
                                 key={index}
+                                line={props.logLines[index][0]}
+                                count={props.logLines[index][1]}
                                 style={style}
                             />
                         )}

--- a/owmods_gui/frontend/src/styles/logs.scss
+++ b/owmods_gui/frontend/src/styles/logs.scss
@@ -62,13 +62,14 @@ $log-border: 1px solid var(--accent-bg);
 .log-line {
     height: fit-content;
     display: grid;
-    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-columns: auto minmax(0, 1fr) auto;
     width: 100%;
     padding: $margin $margin-md;
     border-bottom: $log-border;
 }
 
 .log-line .sender,
+.log-line .count,
 .log-line .message {
     display: flex;
     align-items: center;
@@ -92,8 +93,9 @@ $log-border: 1px solid var(--accent-bg);
 }
 
 .log-line .count {
-    // GRRR I AM STUPID
-    white-space: normal;
+    flex-shrink: 1;
+    margin-left: $margin-lg;
+    white-space: nowrap;
 }
 
 .log-line .message.type-message {

--- a/owmods_gui/frontend/src/styles/logs.scss
+++ b/owmods_gui/frontend/src/styles/logs.scss
@@ -91,6 +91,11 @@ $log-border: 1px solid var(--accent-bg);
     white-space: nowrap;
 }
 
+.log-line .count {
+    // GRRR I AM STUPID
+    white-space: normal;
+}
+
 .log-line .message.type-message {
     color: var(--log-message);
 }

--- a/owmods_gui/frontend/src/styles/logs.scss
+++ b/owmods_gui/frontend/src/styles/logs.scss
@@ -93,9 +93,18 @@ $log-border: 1px solid var(--accent-bg);
 }
 
 .log-line .count {
+    font-size: small;
     flex-shrink: 1;
     margin-left: $margin-lg;
+    margin-right: $margin;
+    background-color: var(--accent-bg-lighter);
+    padding: 0 $margin-md;
+    border-radius: 10px;
     white-space: nowrap;
+}
+
+.log-line .count::before {
+    content: "x";
 }
 
 .log-line .message.type-message {


### PR DESCRIPTION
# Make Logs Collapse

<!-- Which packages this PR affects -->
## Package(s)

- [x] GUI
- [ ] CLI
- [ ] Core
- [ ] None

<!-- Long description of what you changed -->
## Description
neighbors are now collapsed into a single count, like the old manager

![image](https://user-images.githubusercontent.com/26337121/233491565-69e900a9-86eb-4b63-8227-f2439d5e69ed.png)
