### PR TITLE
[GUI] Remove redundant usage of useMemo

### DIFF
--- a/owmods_gui/frontend/src/components/main/mods/local/LocalModRow.tsx
+++ b/owmods_gui/frontend/src/components/main/mods/local/LocalModRow.tsx
@@ -147,35 +147,6 @@ const LocalModRow = memo(function LocalModRow(props: LocalModRowProps) {
         commands.fixDeps({ uniqueName: props.uniqueName }).then(() => commands.refreshLocalDb());
     }, [props.uniqueName]);
 
-    const modsToolbar = useMemo(
-        () => (
-            <LocalModActions
-                uniqueName={props.uniqueName}
-                enabled={enabled}
-                isErr={isErr}
-                hasRemote={hasRemote}
-                canFix={canFixWarn}
-                onToggle={onToggle}
-                onReadme={onReadme}
-                onFix={onFix}
-                onFolder={onFolder}
-                onUninstall={onUninstall}
-            />
-        ),
-        [
-            props.uniqueName,
-            enabled,
-            isErr,
-            hasRemote,
-            canFixWarn,
-            onToggle,
-            onReadme,
-            onFix,
-            onFolder,
-            onUninstall
-        ]
-    );
-
     return (
         <ModRow
             uniqueName={props.uniqueName}
@@ -194,7 +165,18 @@ const LocalModRow = memo(function LocalModRow(props: LocalModRowProps) {
             downloads={remote?.downloadCount ?? -1}
             errorLevel={errorLevel}
         >
-            {modsToolbar}
+            <LocalModActions
+                uniqueName={props.uniqueName}
+                enabled={enabled}
+                isErr={isErr}
+                hasRemote={hasRemote}
+                canFix={canFixWarn}
+                onToggle={onToggle}
+                onReadme={onReadme}
+                onFix={onFix}
+                onFolder={onFolder}
+                onUninstall={onUninstall}
+            />
         </ModRow>
     );
 });

--- a/owmods_gui/frontend/src/components/main/mods/local/LocalModsPage.tsx
+++ b/owmods_gui/frontend/src/components/main/mods/local/LocalModsPage.tsx
@@ -24,11 +24,6 @@ const LocalModsPage = memo(function LocalModsPage(props: { show: boolean }) {
         return <LocalModRow uniqueName={uniqueName} />;
     }, []);
 
-    const toggleButtons = useMemo(
-        () => <LocalModsToggleButtons onToggle={onToggleAll} />,
-        [onToggleAll]
-    );
-
     return (
         <ModsPage
             isLoading={status === "Loading" && localMods === null}
@@ -40,7 +35,7 @@ const LocalModsPage = memo(function LocalModsPage(props: { show: boolean }) {
             uniqueNames={localMods ?? []}
             renderRow={renderRow}
         >
-            {toggleButtons}
+            <LocalModsToggleButtons onToggle={onToggleAll} />
         </ModsPage>
     );
 });

--- a/owmods_gui/frontend/src/components/main/mods/remote/RemoteModRow.tsx
+++ b/owmods_gui/frontend/src/components/main/mods/remote/RemoteModRow.tsx
@@ -53,21 +53,6 @@ const RemoteModRow = memo(function RemoteModRow(props: RemoteModRowProps) {
         commands.openModReadme({ uniqueName: props.uniqueName }).catch(console.warn);
     }, [props.uniqueName]);
 
-    const modActions = useMemo(
-        () => (
-            <RemoteModActions
-                uniqueName={props.uniqueName}
-                busy={busy ?? false}
-                showPrerelease={hasPrerelease}
-                prereleaseLabel={prereleaseLabel}
-                onInstall={onInstall}
-                onPrerelease={onPrerelease}
-                onReadme={onReadme}
-            />
-        ),
-        [busy, onInstall, onPrerelease, onReadme, prereleaseLabel, props.uniqueName, hasPrerelease]
-    );
-
     return (
         <ModRow
             uniqueName={props.uniqueName}
@@ -78,7 +63,15 @@ const RemoteModRow = memo(function RemoteModRow(props: RemoteModRowProps) {
             downloads={remote?.downloadCount ?? -1}
             version={remote?.version ?? "0.0.0"}
         >
-            {modActions}
+            <RemoteModActions
+                uniqueName={props.uniqueName}
+                busy={busy ?? false}
+                showPrerelease={hasPrerelease}
+                prereleaseLabel={prereleaseLabel}
+                onInstall={onInstall}
+                onPrerelease={onPrerelease}
+                onReadme={onReadme}
+            />
         </ModRow>
     );
 });


### PR DESCRIPTION
# [Title Here]

<!-- Which packages this PR affects -->
## Package(s)

- [x] GUI
- [ ] CLI
- [ ] Core
- [ ] None

<!-- Long description of what you changed -->
## Description

I think we talked about your usage of `useMemo` before. Personally it seems like pretty much every usage of useMemo currently in the project seems unnecessary, but I didn't look too deeply into every one of them. The ones I removed here seem 100% redundant since the components themselves are wrapped in memo too.