### PR TITLE
Button styling changes and reduce vertical space

### DIFF
--- a/owmods_gui/frontend/src/components/common/FileInput.tsx
+++ b/owmods_gui/frontend/src/components/common/FileInput.tsx
@@ -34,7 +34,7 @@ const FileInput = <T,>(openFunc: (options?: T) => Promise<string | string[] | nu
                     label={props.label}
                     sx={{ flexGrow: 1 }}
                 />
-                <Button onClick={onBrowse} startIcon={<FolderRounded />}>
+                <Button variant="contained" onClick={onBrowse} startIcon={<FolderRounded />}>
                     {getTranslation("BROWSE")}
                 </Button>
             </Box>

--- a/owmods_gui/frontend/src/components/common/FilterInput.tsx
+++ b/owmods_gui/frontend/src/components/common/FilterInput.tsx
@@ -31,7 +31,8 @@ const FilterInput: React.FunctionComponent<FilterInputProps> = ({
 
     return (
         <TextField
-            margin="dense"
+            margin="none"
+            size="small"
             onChange={({ currentTarget }) => {
                 setFilterText(currentTarget.value);
             }}

--- a/owmods_gui/frontend/src/components/main/MainApp.tsx
+++ b/owmods_gui/frontend/src/components/main/MainApp.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@mui/material";
+import { Box, Paper } from "@mui/material";
 import TopBar from "./top-bar/TopBar";
 import { useEffect, useState } from "react";
 import { TabContext } from "@mui/lab";

--- a/owmods_gui/frontend/src/components/main/mods/ModRow.tsx
+++ b/owmods_gui/frontend/src/components/main/mods/ModRow.tsx
@@ -109,7 +109,7 @@ const ModRow = memo(function GenericModRow(props: ModRowProps) {
                 </Typography>
                 <Box>
                     <Typography
-                        color={isErr ? theme.palette.secondary.light : theme.palette.text.primary}
+                        color={isErr ? theme.palette.secondary.light : theme.palette.text.secondary}
                         variant="caption"
                     >
                         {props.isLoading || props.remoteIsLoading ? (

--- a/owmods_gui/frontend/src/components/main/mods/ModsPage.tsx
+++ b/owmods_gui/frontend/src/components/main/mods/ModsPage.tsx
@@ -21,18 +21,19 @@ const ModsPage = memo(function ModsPage(props: ModsPageProps) {
     return (
         <Container
             sx={{
-                paddingY: theme.spacing(3),
+                padding: theme.spacing(2),
                 height: "100%",
                 display: props.show ? "flex" : "none",
                 flexDirection: "column"
             }}
+            disableGutters
             maxWidth="xl"
         >
             <ModsToolbar filter={props.filter} onFilterChanged={props.onFilterChange}>
                 {props.children}
             </ModsToolbar>
             {props.isLoading ? (
-                <Paper sx={{ marginTop: theme.spacing(3), height: "100%" }}>
+                <Paper sx={{ marginTop: theme.spacing(2), height: "100%" }}>
                     <Box height="100%" display="flex" alignItems="center" justifyContent="center">
                         <CircularProgress color="secondary" />
                     </Box>
@@ -40,7 +41,7 @@ const ModsPage = memo(function ModsPage(props: ModsPageProps) {
             ) : props.uniqueNames.length !== 0 ? (
                 <ModsTable {...props} />
             ) : (
-                <Paper sx={{ marginTop: theme.spacing(3), height: "100%" }}>
+                <Paper sx={{ marginTop: theme.spacing(2), height: "100%" }}>
                     <Box height="100%" display="flex" alignItems="center" justifyContent="center">
                         <Typography variant="subtitle1">{props.noModsText}</Typography>
                     </Box>

--- a/owmods_gui/frontend/src/components/main/mods/ModsTable.tsx
+++ b/owmods_gui/frontend/src/components/main/mods/ModsTable.tsx
@@ -24,7 +24,7 @@ const ScrollerComp = forwardRef<HTMLDivElement>(function TScroller(props, ref) {
     const theme = useTheme();
     return (
         <TableContainer
-            sx={{ marginTop: theme.spacing(3) }}
+            sx={{ marginTop: theme.spacing(2) }}
             component={Paper}
             {...props}
             ref={ref}

--- a/owmods_gui/frontend/src/components/main/mods/ModsToolbar.tsx
+++ b/owmods_gui/frontend/src/components/main/mods/ModsToolbar.tsx
@@ -14,16 +14,13 @@ const ModsToolbar = memo(function GenericModsToolbar(props: ModsToolbarProps) {
     const getTranslation = useGetTranslation();
 
     return (
-        <Paper
-            sx={{
-                padding: theme.spacing(1)
-            }}
-        >
+        <Paper sx={{ padding: 1 }}>
             <Toolbar
+                disableGutters
+                variant="dense"
                 sx={{
                     justifyContent: "space-between",
-                    minHeight: 0,
-                    padding: 0
+                    minHeight: 0
                 }}
             >
                 <FilterInput

--- a/owmods_gui/frontend/src/components/main/mods/local/LocalModsToggleButtons.tsx
+++ b/owmods_gui/frontend/src/components/main/mods/local/LocalModsToggleButtons.tsx
@@ -1,5 +1,5 @@
 import { useGetTranslation } from "@hooks";
-import { Button, ButtonGroup, useTheme } from "@mui/material";
+import { Button, ButtonGroup } from "@mui/material";
 import { memo } from "react";
 
 export interface LocalModsToggleButtonsProps {
@@ -8,20 +8,11 @@ export interface LocalModsToggleButtonsProps {
 
 const LocalModsToggleButtons = memo(function LocalModsToolbar(props: LocalModsToggleButtonsProps) {
     const getTranslation = useGetTranslation();
-    const theme = useTheme();
-
-    const buttonStyle = {
-        padding: theme.spacing(1.5)
-    };
 
     return (
         <ButtonGroup>
-            <Button style={buttonStyle} onClick={() => props.onToggle(true)}>
-                {getTranslation("ENABLE_ALL")}
-            </Button>
-            <Button style={buttonStyle} onClick={() => props.onToggle(false)}>
-                {getTranslation("DISABLE_ALL")}
-            </Button>
+            <Button onClick={() => props.onToggle(true)}>{getTranslation("ENABLE_ALL")}</Button>
+            <Button onClick={() => props.onToggle(false)}>{getTranslation("DISABLE_ALL")}</Button>
         </ButtonGroup>
     );
 });

--- a/owmods_gui/frontend/src/components/main/mods/remote/RemoteModsPage.tsx
+++ b/owmods_gui/frontend/src/components/main/mods/remote/RemoteModsPage.tsx
@@ -25,7 +25,6 @@ const RemoteModsPage = memo(function RemoteModsPage(props: { show: boolean }) {
                 sx={{
                     padding: theme.spacing(1.5)
                 }}
-                variant="outlined"
                 onClick={() => shell.open("https://outerwildsmods.com/mods")}
                 startIcon={<PublicRounded />}
             >

--- a/owmods_gui/frontend/src/components/main/mods/remote/RemoteModsPage.tsx
+++ b/owmods_gui/frontend/src/components/main/mods/remote/RemoteModsPage.tsx
@@ -22,9 +22,6 @@ const RemoteModsPage = memo(function RemoteModsPage(props: { show: boolean }) {
     const modsWebsiteButton = useMemo(
         () => (
             <Button
-                sx={{
-                    padding: theme.spacing(1.5)
-                }}
                 onClick={() => shell.open("https://outerwildsmods.com/mods")}
                 startIcon={<PublicRounded />}
             >

--- a/owmods_gui/frontend/src/components/main/mods/updates/UpdateModsPage.tsx
+++ b/owmods_gui/frontend/src/components/main/mods/updates/UpdateModsPage.tsx
@@ -37,7 +37,6 @@ const UpdateModsPage = memo(function UpdateModsPage(props: { show: boolean }) {
                     padding: theme.spacing(1.5)
                 }}
                 disabled={updateMods?.length === 0 || updatingAll}
-                variant="outlined"
                 onClick={onUpdateAll}
                 startIcon={<UpdateRounded />}
             >

--- a/owmods_gui/frontend/src/components/main/mods/updates/UpdateModsPage.tsx
+++ b/owmods_gui/frontend/src/components/main/mods/updates/UpdateModsPage.tsx
@@ -33,9 +33,6 @@ const UpdateModsPage = memo(function UpdateModsPage(props: { show: boolean }) {
     const updateAllButton = useMemo(
         () => (
             <Button
-                sx={{
-                    padding: theme.spacing(1.5)
-                }}
                 disabled={updateMods?.length === 0 || updatingAll}
                 onClick={onUpdateAll}
                 startIcon={<UpdateRounded />}

--- a/owmods_gui/frontend/src/components/main/top-bar/AppTabs.tsx
+++ b/owmods_gui/frontend/src/components/main/top-bar/AppTabs.tsx
@@ -2,7 +2,7 @@ import { hooks } from "@commands";
 import { useGetTranslation } from "@hooks";
 import { ComputerRounded, PublicRounded, UpdateRounded } from "@mui/icons-material";
 import TabList from "@mui/lab/TabList";
-import { Paper, useTheme } from "@mui/material";
+import { AppBar, Paper, useTheme } from "@mui/material";
 import Tab from "@mui/material/Tab";
 import { FunctionComponent } from "react";
 
@@ -14,7 +14,7 @@ const AppTabs: FunctionComponent<{ onChange: (newVal: string) => void }> = ({ on
     const countText = count === 0 ? "" : `(${count})`;
 
     return (
-        <Paper elevation={3}>
+        <AppBar position="static">
             <TabList
                 sx={{ margin: `0 ${theme.spacing(3)}` }}
                 onChange={(_, newVal) => onChange(newVal)}
@@ -41,7 +41,7 @@ const AppTabs: FunctionComponent<{ onChange: (newVal: string) => void }> = ({ on
                     label={getTranslation("UPDATES", { amount: countText })}
                 />
             </TabList>
-        </Paper>
+        </AppBar>
     );
 };
 

--- a/owmods_gui/frontend/src/components/main/top-bar/TopBar.tsx
+++ b/owmods_gui/frontend/src/components/main/top-bar/TopBar.tsx
@@ -5,7 +5,7 @@ import { memo } from "react";
 
 const TopBar = memo(function TopBar() {
     return (
-        <AppBar position="sticky" component="nav">
+        <AppBar position="static" component="nav" elevation={2}>
             <Toolbar>
                 <AppIcons />
                 <div style={{ flexGrow: 1 }} />

--- a/owmods_gui/frontend/src/components/main/top-bar/overflow/Import.tsx
+++ b/owmods_gui/frontend/src/components/main/top-bar/overflow/Import.tsx
@@ -83,10 +83,10 @@ const Import = memo(function Import({ onClick }: ModalProps) {
                     />
                 </DialogContent>
                 <DialogActions>
-                    <Button color="neutral" onClick={onClose}>
-                        {getTranslation("CANCEL")}
+                    <Button onClick={onClose}>{getTranslation("CANCEL")}</Button>
+                    <Button variant="contained" color="primary" onClick={onImport}>
+                        {getTranslation("IMPORT")}
                     </Button>
-                    <Button onClick={onImport}>{getTranslation("IMPORT")}</Button>
                 </DialogActions>
             </Dialog>
         </>

--- a/owmods_gui/frontend/src/components/main/top-bar/overflow/InstallFrom.tsx
+++ b/owmods_gui/frontend/src/components/main/top-bar/overflow/InstallFrom.tsx
@@ -196,10 +196,10 @@ const InstallFrom = memo(function InstallFrom({ onClick }: ModalProps) {
                     </Box>
                 </DialogContent>
                 <DialogActions>
-                    <Button color="neutral" onClick={onClose}>
-                        {getTranslation("CANCEL")}
+                    <Button onClick={onClose}>{getTranslation("CANCEL")}</Button>
+                    <Button variant="contained" color="primary" onClick={onInstall}>
+                        {getTranslation("INSTALL")}
                     </Button>
-                    <Button onClick={onInstall}>{getTranslation("INSTALL")}</Button>
                 </DialogActions>
             </Dialog>
         </>

--- a/owmods_gui/frontend/src/components/main/top-bar/settings/SettingsHeader.tsx
+++ b/owmods_gui/frontend/src/components/main/top-bar/settings/SettingsHeader.tsx
@@ -12,11 +12,7 @@ const ResetButton = memo(function ResetButton(props: { onClick?: () => void }) {
     const getTranslation = useGetTranslation();
 
     return (
-        <Button
-            color="secondary"
-            onClick={props.onClick}
-            startIcon={<SettingsBackupRestoreRounded />}
-        >
+        <Button onClick={props.onClick} startIcon={<SettingsBackupRestoreRounded />}>
             {getTranslation("RESET")}
         </Button>
     );

--- a/owmods_gui/frontend/src/components/main/top-bar/settings/SettingsModal.tsx
+++ b/owmods_gui/frontend/src/components/main/top-bar/settings/SettingsModal.tsx
@@ -66,10 +66,10 @@ const SettingsModal = memo(function SettingsModal({ open, onClose }: SettingsMod
                 )}
             </DialogContent>
             <DialogActions>
-                <Button color="neutral" onClick={onCancel}>
-                    {getTranslation("CANCEL")}
+                <Button onClick={onCancel}>{getTranslation("CANCEL")}</Button>
+                <Button color="primary" variant="contained" onClick={onSave}>
+                    {getTranslation("SAVE")}
                 </Button>
-                <Button onClick={onSave}>{getTranslation("SAVE")}</Button>
             </DialogActions>
         </Dialog>
     );

--- a/owmods_gui/frontend/src/theme.ts
+++ b/owmods_gui/frontend/src/theme.ts
@@ -17,6 +17,12 @@ declare module "@mui/material/Button" {
     }
 }
 
+declare module "@mui/material/ButtonGroup" {
+    export interface ButtonGroupPropsColorOverrides {
+        neutral: true;
+    }
+}
+
 declare module "@mui/material/CircularProgress" {
     export interface CircularProgressPropsColorOverrides {
         neutral: true;
@@ -35,8 +41,8 @@ export default createTheme({
             light: "#ffc380"
         },
         neutral: {
-            main: grey[400],
-            contrastText: "#fff"
+            main: grey[300],
+            contrastText: "#1c1c1c"
         },
         error: {
             main: red[500],
@@ -73,6 +79,18 @@ export default createTheme({
                 tooltip: {
                     fontSize: "1em"
                 }
+            }
+        },
+        MuiButton: {
+            defaultProps: {
+                variant: "outlined",
+                color: "neutral"
+            }
+        },
+        MuiButtonGroup: {
+            defaultProps: {
+                variant: "outlined",
+                color: "neutral"
             }
         }
     }

--- a/owmods_gui/frontend/src/theme.ts
+++ b/owmods_gui/frontend/src/theme.ts
@@ -90,6 +90,14 @@ export default createTheme({
                 }
             }
         },
+        MuiTableCell: {
+            styleOverrides: {
+                head: {
+                    paddingTop: 10,
+                    paddingBottom: 10
+                }
+            }
+        },
         MuiTooltip: {
             styleOverrides: {
                 tooltip: {

--- a/owmods_gui/frontend/src/theme.ts
+++ b/owmods_gui/frontend/src/theme.ts
@@ -74,6 +74,22 @@ export default createTheme({
                 }
             }
         },
+        MuiTab: {
+            styleOverrides: {
+                root: {
+                    minHeight: 0,
+                    padding: 10
+                }
+            }
+        },
+        MuiTabs: {
+            styleOverrides: {
+                root: {
+                    minHeight: 0,
+                    padding: 0
+                }
+            }
+        },
         MuiTooltip: {
             styleOverrides: {
                 tooltip: {


### PR DESCRIPTION
<!-- Which packages this PR affects -->
## Package(s)

- [x] GUI
- [ ] CLI
- [ ] Core
- [ ] None

Tried to improve contrast in buttons. Only use outline with neutral color, everything else is contained. Don't use the non-outlined one since it's not as obvious that it's a button. Also made sure to always have a "cta" button in green contained for every screen (main screen and modals).

Also tried to reduce all the paddings so we don't waste so much vertical space. Because currently this manager loses a lot of vertical space compared to the old one, since we now have four separate sticky elements instead of just one.

![image](https://github.com/Bwc9876/ow-mod-man/assets/3955124/80c24d21-5958-4b9d-a22e-549bef2cb574)
![image](https://github.com/Bwc9876/ow-mod-man/assets/3955124/52318228-d557-44ce-b9ca-cd6b335b93e9)
![image](https://github.com/Bwc9876/ow-mod-man/assets/3955124/9af167cc-4f12-477e-a4dc-ae87570d5962)

