### PR TITLE
[GUI] Get rid of uninstall confirmation dialog

### DIFF
--- a/owmods_gui/frontend/src/assets/translations/english.json
+++ b/owmods_gui/frontend/src/assets/translations/english.json
@@ -119,7 +119,6 @@
     "TOOLTIP_WATCH_FS": "Watches OWML's Mods folder and settings for changes and refreshes if detected",
     "UNKNOWN_ERROR": "Unknown Error",
     "UNINSTALL": "Uninstall",
-    "UNINSTALL_CONFIRM": "Are you sure you want to uninstall $name$?",
     "UNIQUE_NAME": "Unique Name",
     "UPDATE": "Update",
     "UPDATES": "Updates $amount$",

--- a/owmods_gui/frontend/src/assets/translations/template.json
+++ b/owmods_gui/frontend/src/assets/translations/template.json
@@ -112,7 +112,6 @@
     "TOOLTIP_OWML_PATH": "",
     "TOOLTIP_WATCH_FS": "",
     "UNINSTALL": "",
-    "UNINSTALL_CONFIRM": "",
     "UNIQUE_NAME": "",
     "UPDATE": "",
     "UPDATES": "",

--- a/owmods_gui/frontend/src/components/main/mods/local/LocalModRow.tsx
+++ b/owmods_gui/frontend/src/components/main/mods/local/LocalModRow.tsx
@@ -129,23 +129,16 @@ const LocalModRow = memo(function LocalModRow(props: LocalModRowProps) {
         [autoEnableDeps, getTranslation, props.uniqueName]
     );
     const onUninstall = useCallback(() => {
-        const uninstallConfirmText = getTranslation("UNINSTALL_CONFIRM", {
-            name
-        });
-        dialog.confirm(uninstallConfirmText, getTranslation("CONFIRM")).then((answer) => {
-            if (answer) {
-                commands.uninstallMod({ uniqueName: props.uniqueName }).then((warnings) => {
-                    commands.refreshLocalDb();
-                    for (const modName of warnings) {
-                        dialog.message(getTranslation("PREPATCHER_WARNING", { name: modName }), {
-                            type: "warning",
-                            title: getTranslation("PREPATCHER_WARNING_TITLE", { name: modName })
-                        });
-                    }
+        commands.uninstallMod({ uniqueName: props.uniqueName }).then((warnings) => {
+            commands.refreshLocalDb();
+            for (const modName of warnings) {
+                dialog.message(getTranslation("PREPATCHER_WARNING", { name: modName }), {
+                    type: "warning",
+                    title: getTranslation("PREPATCHER_WARNING_TITLE", { name: modName })
                 });
             }
         });
-    }, [getTranslation, name, props.uniqueName]);
+    }, [getTranslation, props.uniqueName]);
     const onFix = useCallback(() => {
         const task = async () => {
             if (outdated) {


### PR DESCRIPTION
<!-- Which packages this PR affects -->
## Package(s)

- [x] GUI
- [ ] CLI
- [ ] Core
- [ ] None

Three clicks to uninstall a mod is too many clicks. Either remove it from the submenu, or remove the confirmation dialogue. I went with the second option.

I also feel like people being used to immediately closing dialogs will make them not read the actual important ones that show up when uninstalling some mods.

But of course feel free to close it if you disagree.